### PR TITLE
No Geom Type

### DIFF
--- a/bcdata/bc2pg.py
+++ b/bcdata/bc2pg.py
@@ -110,9 +110,9 @@ def bc2pg(
                 df_temp.has_z.unique()[0]
             ):  # geopandas does not include Z in geom_type string
                 geometry_type = geometry_type + "Z"
-            # drop the last request url to free up memory
+            # drop the last request dataframe to free up memory
             del(df_temp)
-            
+
         # ensure geom type is valid
         geometry_type = geometry_type.upper()
         if geometry_type not in SUPPORTED_TYPES:

--- a/bcdata/bc2pg.py
+++ b/bcdata/bc2pg.py
@@ -100,7 +100,19 @@ def bc2pg(
                 df.has_z.unique()[0]
             ):  # geopandas does not include Z in geom_type string
                 geometry_type = geometry_type + "Z"
-
+                # if geometry type is still not populated try the last request incase all entrys with geom are near the bottom
+        if not geometry_type:
+            df_temp = WFS.make_requests(
+                [urls[-1]], as_gdf=True, crs="epsg:3005", lowercase=True, silent=True
+            )
+            geometry_type = df_temp.geom_type.unique()[0]  # keep only the first type
+            if numpy.any(
+                df_temp.has_z.unique()[0]
+            ):  # geopandas does not include Z in geom_type string
+                geometry_type = geometry_type + "Z"
+            # drop the last request url to free up memory
+            del(df_temp)
+            
         # ensure geom type is valid
         geometry_type = geometry_type.upper()
         if geometry_type not in SUPPORTED_TYPES:

--- a/bcdata/bc2pg.py
+++ b/bcdata/bc2pg.py
@@ -102,16 +102,17 @@ def bc2pg(
                 geometry_type = geometry_type + "Z"
                 # if geometry type is still not populated try the last request incase all entrys with geom are near the bottom
         if not geometry_type:
-            df_temp = WFS.make_requests(
-                [urls[-1]], as_gdf=True, crs="epsg:3005", lowercase=True, silent=True
-            )
-            geometry_type = df_temp.geom_type.unique()[0]  # keep only the first type
-            if numpy.any(
-                df_temp.has_z.unique()[0]
-            ):  # geopandas does not include Z in geom_type string
-                geometry_type = geometry_type + "Z"
-            # drop the last request dataframe to free up memory
-            del(df_temp)
+            if not urls[-1] == urls[0]:
+                df_temp = WFS.make_requests(
+                    [urls[-1]], as_gdf=True, crs="epsg:3005", lowercase=True, silent=True
+                )
+                geometry_type = df_temp.geom_type.unique()[0]  # keep only the first type
+                if numpy.any(
+                    df_temp.has_z.unique()[0]
+                ):  # geopandas does not include Z in geom_type string
+                    geometry_type = geometry_type + "Z"
+                # drop the last request dataframe to free up memory
+                del(df_temp)
 
         # ensure geom type is valid
         geometry_type = geometry_type.upper()

--- a/bcdata/wfs.py
+++ b/bcdata/wfs.py
@@ -140,10 +140,11 @@ class BCWFS(object):
         return int(ET.fromstring(r.text).attrib["numberMatched"])
 
     @stamina.retry(on=requests.HTTPError, timeout=60)
-    def _request_features(self, url):
+    def _request_features(self, url, silent = False):
         """Submit a getfeature request to DataBC WFS and return features"""
         r = requests.get(url, headers=self.request_headers)
-        log.info(r.url)
+        if not silent:
+            log.info(r.url)
         if r.status_code in [400, 401, 404]:
             log.error(f"HTTP error {r.status_code}")
             log.error(f"Response headers: {r.headers}")
@@ -344,12 +345,12 @@ class BCWFS(object):
             urls.append(self.wfs_url + "?" + urlencode(request, doseq=True))
         return urls
 
-    def make_requests(self, urls, as_gdf=False, crs="epsg4326", lowercase=False):
+    def make_requests(self, urls, as_gdf=False, crs="epsg4326", lowercase=False, silent = False):
         """turn urls into data"""
         # loop through urls
         results = []
         for url in urls:
-            results.append(self._request_features(url))
+            results.append(self._request_features(url, silent))
         outjson = dict(type="FeatureCollection", features=[])
         for result in results:
             outjson["features"] += result


### PR DESCRIPTION
Added a check on the last request of data for geometry type. This is useful in cases where the geom is all at the end of the dataset one example of this is for the dataset `water-rights-applications-public`. Also added the ability to suppress the request log so reading logs in the case where this second check is used is not confusing for users why the last request was made.